### PR TITLE
fix: Demote health-check and stats logs to DEBUG (#14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,7 +576,7 @@ When `SELECTORS_REMOTE_URL` is configured, selectors are fetched periodically fr
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `LOG_LEVEL` | `info` | Log level (debug, info, warn, error) |
+| `LOG_LEVEL` | `info` | Log level (trace, debug, info, warn, error). Health-check request logs and periodic `Server stats` are emitted at `debug`, so set `LOG_LEVEL=debug` to see them. |
 | `LOG_HTML` | `false` | Log HTML responses (verbose) |
 | `LOG_FILE` | (none) | Path to log file (in addition to stdout) |
 | `TZ` | (none) | Browser timezone (e.g., `America/New_York`) |

--- a/cmd/flaresolverr/main.go
+++ b/cmd/flaresolverr/main.go
@@ -290,6 +290,8 @@ func setupLogging(level, logFile string) {
 	log.Logger = log.Output(output)
 
 	switch level {
+	case "trace":
+		zerolog.SetGlobalLevel(zerolog.TraceLevel)
 	case "debug":
 		zerolog.SetGlobalLevel(zerolog.DebugLevel)
 	case "info":

--- a/internal/browser/stealth_test.go
+++ b/internal/browser/stealth_test.go
@@ -13,7 +13,7 @@ func TestGate2CorrectionsScriptContent(t *testing.T) {
 	mustContain := []string{
 		"WebGLRenderingContext",
 		"WebGL2RenderingContext",
-		"ANGLE (Intel",       // Linux ANGLE renderer
+		"ANGLE (Intel",        // Linux ANGLE renderer
 		"Google Inc. (Intel)", // Linux ANGLE vendor
 		"availWidth",
 		"availHeight",

--- a/internal/captcha/ninekw.go
+++ b/internal/captcha/ninekw.go
@@ -209,7 +209,7 @@ func (s *NineKwSolver) submit(ctx context.Context, oldsource, sitekey, pageURL, 
 }
 
 // poll retrieves the solved token, blocking until ready, the budget expires, or
-// the context is cancelled.
+// the context is canceled.
 func (s *NineKwSolver) poll(ctx context.Context, captchaID string) (string, error) {
 	pollCtx, cancel := context.WithTimeout(ctx, s.timeout)
 	defer cancel()

--- a/internal/captcha/ninekw_test.go
+++ b/internal/captcha/ninekw_test.go
@@ -67,7 +67,7 @@ func TestNineKwSolver_SolveTurnstile_Unsupported(t *testing.T) {
 }
 
 func TestNineKwSolver_SolveHCaptcha_Success(t *testing.T) {
-	const wantToken = "P0_eyJ0eXAfor-hcaptcha"
+	const wantToken = "P0_eyJ0eXAfor-hcaptcha" //nolint:gosec // test fixture, not a real credential
 	polls := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		q := r.URL.Query()

--- a/internal/dashboard/logreporter.go
+++ b/internal/dashboard/logreporter.go
@@ -86,8 +86,9 @@ func (r *LogReporter) reportLoop() {
 func (r *LogReporter) report() {
 	snap := r.collector.Collect(logReporterMaxRows)
 
-	// Server stats
-	log.Info().
+	// Server stats — demoted to debug so periodic stats don't spam the default
+	// info log (#14); surface with LOG_LEVEL=debug.
+	log.Debug().
 		Str("uptime", formatDuration(snap.Uptime)).
 		Int64("total_requests", snap.TotalRequests).
 		Str("req_per_sec", fmt.Sprintf("%.1f", snap.RequestsPerSec)).
@@ -101,7 +102,7 @@ func (r *LogReporter) report() {
 
 	// Top domains (if any)
 	for _, d := range snap.TopDomains {
-		log.Info().
+		log.Debug().
 			Str("domain", d.Domain).
 			Int64("requests", d.RequestCount).
 			Str("success_rate", fmt.Sprintf("%.0f%%", d.SuccessRate)).

--- a/internal/middleware/logging.go
+++ b/internal/middleware/logging.go
@@ -7,8 +7,23 @@ import (
 	"strings"
 	"time"
 
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
+
+// infraLogPaths holds monitoring endpoints whose request logs are demoted to
+// debug, so health polling doesn't spam the default info log (#14).
+var infraLogPaths = map[string]bool{"/health": true}
+
+// requestLogLevel returns the log level for a completed request. Monitoring
+// endpoints (see infraLogPaths) are demoted to debug; everything else stays at
+// info.
+func requestLogLevel(path string) zerolog.Level {
+	if infraLogPaths[path] {
+		return zerolog.DebugLevel
+	}
+	return zerolog.InfoLevel
+}
 
 // sensitiveParams contains query parameter names that may contain secrets
 // and should be redacted in logs.
@@ -112,7 +127,7 @@ func Logging(next http.Handler) http.Handler {
 		// Log after completion
 		duration := time.Since(start)
 
-		log.Info().
+		log.WithLevel(requestLogLevel(r.URL.Path)).
 			Str("method", r.Method).
 			Str("path", sanitizeURLForLogging(r.URL.String())).
 			Str("remote_addr", maskIP(r.RemoteAddr)).

--- a/internal/middleware/middleware_test.go
+++ b/internal/middleware/middleware_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rs/zerolog"
+
 	"github.com/Rorqualx/flaresolverr-go/internal/config"
 )
 
@@ -88,6 +90,27 @@ func TestLoggingMiddlewareCapturesStatusCode(t *testing.T) {
 
 	if w.Code != http.StatusNotFound {
 		t.Errorf("Expected status 404, got %d", w.Code)
+	}
+}
+
+func TestRequestLogLevel(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want zerolog.Level
+	}{
+		{"health is demoted to debug", "/health", zerolog.DebugLevel},
+		{"v1 stays info", "/v1", zerolog.InfoLevel},
+		{"index stays info", "/", zerolog.InfoLevel},
+		{"unknown path stays info", "/whatever", zerolog.InfoLevel},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := requestLogLevel(tt.path); got != tt.want {
+				t.Errorf("requestLogLevel(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/solver/clearance_cache.go
+++ b/internal/solver/clearance_cache.go
@@ -26,8 +26,8 @@ const (
 	cfClearanceCookie   = "cf_clearance"
 )
 
-// clearanceEntry holds reusable Cloudflare clearance state for one (domain, egress).
-type clearanceEntry struct {
+// ClearanceEntry holds reusable Cloudflare clearance state for one (domain, egress).
+type ClearanceEntry struct {
 	cookies   []types.RequestCookie // ready to inject before navigation
 	userAgent string
 	expiresAt time.Time
@@ -35,31 +35,31 @@ type clearanceEntry struct {
 
 // ClearanceCache is a bounded, TTL'd store of cf_clearance cookies.
 type ClearanceCache struct {
-	mu      sync.RWMutex
-	entries map[string]*clearanceEntry
-	ttl     time.Duration
-	max     int
-	now     func() time.Time // injectable for tests
+	mu         sync.RWMutex
+	entries    map[string]*ClearanceEntry
+	ttl        time.Duration
+	maxEntries int
+	now        func() time.Time // injectable for tests
 }
 
 // NewClearanceCache creates a cache with the given TTL ceiling and max entries.
-func NewClearanceCache(ttl time.Duration, max int) *ClearanceCache {
+func NewClearanceCache(ttl time.Duration, maxEntries int) *ClearanceCache {
 	if ttl <= 0 {
 		ttl = defaultClearanceTTL
 	}
-	if max <= 0 {
-		max = maxClearanceEntries
+	if maxEntries <= 0 {
+		maxEntries = maxClearanceEntries
 	}
 	return &ClearanceCache{
-		entries: make(map[string]*clearanceEntry),
-		ttl:     ttl,
-		max:     max,
-		now:     time.Now,
+		entries:    make(map[string]*ClearanceEntry),
+		ttl:        ttl,
+		maxEntries: maxEntries,
+		now:        time.Now,
 	}
 }
 
 // Get returns a fresh cached clearance for (domain, egress), or nil on miss/expiry.
-func (c *ClearanceCache) Get(domain, egress string) *clearanceEntry {
+func (c *ClearanceCache) Get(domain, egress string) *ClearanceEntry {
 	if c == nil || domain == "" {
 		return nil
 	}
@@ -103,13 +103,13 @@ func (c *ClearanceCache) Put(domain, egress, userAgent string, cookies []*proto.
 		return // already expired; nothing worth caching
 	}
 
-	entry := &clearanceEntry{cookies: reqCookies, userAgent: userAgent, expiresAt: expiresAt}
+	entry := &ClearanceEntry{cookies: reqCookies, userAgent: userAgent, expiresAt: expiresAt}
 	key := clearanceKey(domain, egress)
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.entries[key] = entry
-	if len(c.entries) > c.max {
+	if len(c.entries) > c.maxEntries {
 		c.evictLocked(now)
 	}
 }
@@ -122,7 +122,7 @@ func (c *ClearanceCache) evictLocked(now time.Time) {
 			delete(c.entries, k)
 		}
 	}
-	for len(c.entries) > c.max {
+	for len(c.entries) > c.maxEntries {
 		var oldestKey string
 		var oldest time.Time
 		for k, e := range c.entries {


### PR DESCRIPTION
Closes #14.

## Problem
The default INFO log was unreadable in Docker because two sources spammed it constantly:
- **Health-check request logs** — every `GET /health` poll emits a `Request completed` line (orchestrators poll every few seconds).
- **Server stats** — the `LogReporter` emits `Server stats` (+ `Domain stats`) every 30s.

## Change
Demote both to **DEBUG** — no new config. At the default `LOG_LEVEL=info` they disappear; set `LOG_LEVEL=debug` to see them again.

- `internal/middleware/logging.go` — `requestLogLevel()` + `infraLogPaths` demote `/health` `Request completed` to debug via `log.WithLevel(...)`; `/v1` and everything else stay at info.
- `internal/dashboard/logreporter.go` — `Server stats` / `Domain stats` moved from `log.Info()` → `log.Debug()`.
- `cmd/flaresolverr/main.go` — wire the `trace` level in `setupLogging()` (it was accepted by config validation but silently fell back to info).
- `internal/middleware/middleware_test.go` — `TestRequestLogLevel` (table-driven: `/health`→debug, `/v1`//→info).
- `README.md` — documented the behavior + `trace` level.

## Verification
Local `go build`/`go vet`/`go test ./...` all pass.

Deployed to the Huey live harness (port 8195) at both levels:

| Log line | INFO | DEBUG |
|---|---|---|
| `Request completed` for `/health` | 0 ✅ | 5 (tagged `DBG`) ✅ |
| `Request completed` for `/v1` | 1 ✅ | n/a |
| `Server stats` | 0 ✅ | 1 (tagged `DBG`) ✅ |

Genuine `/v1` traffic stays visible at INFO; the health/stats spam only appears under `LOG_LEVEL=debug`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)